### PR TITLE
Ability to set url root path

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,11 +15,12 @@ import (
 // Client struct is an *Arr client.
 type Client struct {
 	httpClient http.Client
-	URL        url.URL
+	URL            url.URL
+	APIRootPath    string
 }
 
 // NewClient method initializes a new *Arr client.
-func NewClient(baseURL string, insecureSkipVerify bool, auth Authenticator) (*Client, error) {
+func NewClient(baseURL string, insecureSkipVerify bool, auth Authenticator, apiRoot string) (*Client, error) {
 
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -34,6 +35,7 @@ func NewClient(baseURL string, insecureSkipVerify bool, auth Authenticator) (*Cl
 			Transport: NewExportarrTransport(BaseTransport(insecureSkipVerify), auth),
 		},
 		URL: *u,
+		APIRootPath: apiRoot,
 	}, nil
 }
 
@@ -69,7 +71,7 @@ func (c *Client) DoRequest(endpoint string, target interface{}, queryParams ...m
 			values.Add(k, v)
 		}
 	}
-	url := c.URL.JoinPath(endpoint)
+	url := c.URL.JoinPath(c.APIRootPath, endpoint)
 	url.RawQuery = values.Encode()
 	zap.S().Infow("Sending HTTP request",
 		"url", url)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ func RegisterConfigFlags(flags *flag.FlagSet) {
 	flags.StringP("url", "u", "", "URL to *arr instance")
 	flags.StringP("api-key", "a", "", "API Key for *arr instance")
 	flags.String("api-key-file", "", "File containing API Key for *arr instance")
+	flags.String("api-root-path", "", "Root path for api calls.")
 	flags.Bool("disable-ssl-verify", false, "Disable SSL verification")
 	flags.StringP("interface", "i", "", "IP address to listen on")
 	flags.IntP("port", "p", 0, "Port to listen on")
@@ -33,6 +34,7 @@ type Config struct {
 	URL              string `koanf:"url"`
 	ApiKey           string `koanf:"api-key"`
 	ApiKeyFile       string `koanf:"api-key-file"`
+	ApiRootPath      string `koanf:"api-root-path"`
 	Port             int    `koanf:"port" validate:"required"`
 	Interface        string `koanf:"interface" validate:"required|ip"`
 	DisableSSLVerify bool   `koanf:"disable-ssl-verify"`
@@ -44,11 +46,12 @@ func LoadConfig(flags *flag.FlagSet) (*Config, error) {
 
 	// Defaults
 	err := k.Load(confmap.Provider(map[string]interface{}{
-		"log-level":   "info",
-		"log-format":  "console",
-		"api-version": "v3",
-		"port":        "8081",
-		"interface":   "0.0.0.0",
+		"log-level":        "info",
+		"log-format":       "console",
+		"api-version":      "v3",
+		"port":             "8081",
+		"interface":        "0.0.0.0",
+		"api-root-path":    "", 
 	}, "."), nil)
 	if err != nil {
 		return nil, err
@@ -122,6 +125,7 @@ func (c Config) Translates() map[string]string {
 		"ApiKey":           "api-key",
 		"ApiKeyFile":       "api-key-file",
 		"ApiVersion":       "api-version",
+		"ApiRootPath":      "api-root-path",
 		"Port":             "port",
 		"Interface":        "interface",
 		"DisableSSLVerify": "disable-ssl-verify",

--- a/internal/sabnzbd/collector/collector.go
+++ b/internal/sabnzbd/collector/collector.go
@@ -174,7 +174,7 @@ type SabnzbdCollector struct {
 // TODO: Add a sab-specific config struct to abstract away the config parsing
 func NewSabnzbdCollector(config *config.SabnzbdConfig) (*SabnzbdCollector, error) {
 	auther := auth.ApiKeyAuth{ApiKey: config.ApiKey}
-	client, err := client.NewClient(config.URL, config.DisableSSLVerify, auther)
+	client, err := client.NewClient(config.URL, config.DisableSSLVerify, auther, config.ApiRootPath)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to build client: %w", err)
 	}
@@ -187,7 +187,7 @@ func NewSabnzbdCollector(config *config.SabnzbdConfig) (*SabnzbdCollector, error
 }
 
 func (s *SabnzbdCollector) doRequest(mode string, target interface{}) error {
-	return s.client.DoRequest("/sabnzbd/api", target, map[string]string{"mode": mode})
+	return s.client.DoRequest("/api", target, map[string]string{"mode": mode})
 }
 
 func (s *SabnzbdCollector) getQueueStats() (*model.QueueStats, error) {

--- a/internal/sabnzbd/config/config.go
+++ b/internal/sabnzbd/config/config.go
@@ -9,10 +9,13 @@ type SabnzbdConfig struct {
 	URL              string `validate:"required|url"`
 	ApiKey           string `validate:"required"`
 	DisableSSLVerify bool
-	ApiRootPath      string `validate:"required"`
+	ApiRootPath      string 
 }
 
 func LoadSabnzbdConfig(conf base_config.Config) (*SabnzbdConfig, error) {
+	if conf.ApiRootPath == "" {
+		conf.ApiRootPath = "/sabnzbd"
+	}
 	ret := &SabnzbdConfig{
 		URL:              conf.URL,
 		ApiKey:           conf.ApiKey,

--- a/internal/sabnzbd/config/config.go
+++ b/internal/sabnzbd/config/config.go
@@ -9,6 +9,7 @@ type SabnzbdConfig struct {
 	URL              string `validate:"required|url"`
 	ApiKey           string `validate:"required"`
 	DisableSSLVerify bool
+	ApiRootPath      string `validate:"required"`
 }
 
 func LoadSabnzbdConfig(conf base_config.Config) (*SabnzbdConfig, error) {
@@ -16,6 +17,7 @@ func LoadSabnzbdConfig(conf base_config.Config) (*SabnzbdConfig, error) {
 		URL:              conf.URL,
 		ApiKey:           conf.ApiKey,
 		DisableSSLVerify: conf.DisableSSLVerify,
+		ApiRootPath:      conf.ApiRootPath,
 	}
 	return ret, nil
 }


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Ultimately allows the user to set the root path, usually for api calls. Specifically this was added for Sabnzbd as it is hard coded to use `/sabnzbd/api` for the api endpoint. Which is not always the case. Take if you have sabnzb behind a reverse proxy, for example. 

**Benefits**

Configuration of the actual path, versus it being hard coded.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
